### PR TITLE
EP-57: Dockerise our dev env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,12 @@ create-admin:
 create-driver:
 	./build/createdriver.sh
 
+## dev-env: brings dev environemnt up.
 .PHONY: make dev-env
 dev-env:
 	docker-compose up -d
+
+## dev-env-down: brings dev environemnt down.
+.PHONY: make dev-env-down
+dev-env-down:
+	docker-compose down

--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,12 @@ unit:
 vendor:
 	$(GO) mod vendor
 
-## tidy: tidy up mod file
+## tidy: tidy up go mod file
 .PHONY: tidy
 tidy:
 	$(GO) mod tidy
 
-## mocks: generate mocks
+## mocks: generate mocks for unit tests
 .PHONY: mocks
 mocks:
 	rm -rf mocks
@@ -76,3 +76,7 @@ create-admin:
 .PHONY: create-driver
 create-driver:
 	./build/createdriver.sh
+
+.PHONY: make dev-env
+dev-env:
+	docker-compose up -d

--- a/README.md
+++ b/README.md
@@ -17,35 +17,22 @@ API Specification can be found [here](docs/API_SPEC.md).
 #### Mac
 
 - Linux environment(normal terminal on MacOS)
-- VS Code with:
-  - [GoLang extension](https://marketplace.visualstudio.com/items?itemName=golang.Go)
 - [Docker Desktop for Mac](https://docs.docker.com/desktop/install/mac-install/)
-- [GoLang](https://go.dev/doc/install) (Follow instructions for Mac)
+- [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
 
 #### Windows
 
 - Linux environment([WSL2](https://learn.microsoft.com/en-us/windows/wsl/install))
-- VS Code with:
-  - [GoLang extension](https://marketplace.visualstudio.com/items?itemName=golang.Go)
-  - [Remote extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) (need to connect VS Code to WSL2)
 - [Docker Desktop for Windows](https://docs.docker.com/desktop/install/windows-install/) (Download for Windows and [enable integration with WSL2 in the settings](https://docs.docker.com/desktop/wsl/))
-- [GoLang](https://go.dev/doc/install) (Follow instructions for Linux and install in your WSL2)
+- [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
 
-#### Tools
-- [Wire](https://github.com/google/wire) for Dependecy Injection code generation.
-- [Mockery](https://vektra.github.io/mockery/latest/installation/) for Mocks generation for unit testing.
-- PSQL(depends on what package manager your Linux distro uses, but if you try runnining `psql` it should give you a commad back to install it) for running scripts that interact with the database.
-
-### Setting up environment
+### Setting up dev environment
 
 Git clone to your Linux environment using `git clone https://github.com/IgorSteps/easypark.git`.
 
-Open the project in VS Code:
+Run `make dev-env` from project root to bring up the `igorsteps/go-dev:latest` development container with all required tooling. Subsequently you can run `make dev-env-down` to bring it down.
 
-- On Mac: just open it like you would any project.
-- On Windows: use your VS Code Remote Extension to connect to your WSL2 and locate your cloned project there.
-
-From project root in your Linux Environment, run `docker-compose up -d` to create required PostgreSQL image and optional PgAdmin image for DB user interface.
+Attach to it using VS Code's [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
 
 ### Starting the app
 
@@ -54,13 +41,11 @@ From project root, run:
 1. Build the app, run `make build`.
 2. To run the app, run `make run`.
 
-If changes to dependecy graph have been made, you must edit `wire.go` file and run `make wire` to regenerate dependecy injection code(`wire_gen.go` file).
+If changes to dependency graph have been made, you must edit `wire.go` file and run `make wire` to regenerate dependency injection code(`wire_gen.go` file).
 
 ### Troubleshooting
 
-#### Failed to run `make wire` or `make mocks`
-1. Make sure you have `wire`(https://github.com/google/wire) and `mockery`(https://vektra.github.io/mockery/latest/installation/) installed.
-2. If after installation it still doesn't work, add `GO BIN` to your PATH, run `export PATH="$HOME/go/bin:$PATH"`(given that your GO BIN is go/bin which it usuall is).
+TODO
 
 ## Testing
 

--- a/build/cleandb.sh
+++ b/build/cleandb.sh
@@ -4,7 +4,7 @@
 DB_USER="devUser"
 DB_PASSWORD="devPassword"
 DB_NAME="easypark"
-DB_HOST="localhost"
+DB_HOST="database"
 DB_PORT="5432"
 
 TABLES="users,parking_spaces,parking_lots,parking_requests,notifications,alerts"

--- a/build/createadmin.sh
+++ b/build/createadmin.sh
@@ -3,7 +3,7 @@
 DB_USER="devUser"
 DB_PASSWORD="devPassword"
 DB_NAME="easypark"
-DB_HOST="localhost"
+DB_HOST="database"
 DB_PORT="5432"
 
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 # Has to mirror the config in docker-compose.yml.
 database:
-  host: localhost
+  host: database
   port: 5432
   user: devUser
   password: devPassword

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,26 +1,43 @@
-version: "3.8"
-
 services:
+  go-dev:
+    image: igorsteps/go-dev:latest
+    volumes:
+      - .:/ws
+    ports:
+      - "8080:8080"
+      - "8081:8081"
+    environment:
+      PGHOST: postgres
+      PGUSER: postgres
+      PGPASSWORD: example
+      PGDATABASE: postgres
+      PGPORT: 5432
+    depends_on:
+      - database
+    stdin_open: true
+    tty: true
+
   database:
     container_name: database
     image: postgres:latest
     environment:
-      - POSTGRES_USER=devUser
-      - POSTGRES_PASSWORD=devPassword
-      - POSTGRES_DB=easypark
+      POSTGRES_USER: devUser
+      POSTGRES_PASSWORD: devPassword
+      POSTGRES_DB: easypark
     ports:
-      - 5432:5432
+      - "5432:5432"
     volumes:
-      - db:/var/lib/postgresql/data 
+      - db:/var/lib/postgresql/data
 
   pgadmin:
-      image: dpage/pgadmin4
-      environment:
-        PGADMIN_DEFAULT_EMAIL: admin@admin.com
-        PGADMIN_DEFAULT_PASSWORD: admin
-      ports:
-        - "5050:80"
-      depends_on:
-        - database
+    image: dpage/pgadmin4
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@admin.com
+      PGADMIN_DEFAULT_PASSWORD: admin
+    ports:
+      - "5050:80"
+    depends_on:
+      - database
+
 volumes:
   db:


### PR DESCRIPTION
# Ticket link.
EP-57

# Why have you made these changes? What problem it fixes?
We need to standardise a dev environment. Now that we now which tools we use, I have created a Docker container with all of them to avoid manual labour of installing all of the tools on your machines which can result in version mismatch and other headaches.

# What does this implement? Explain your changes.
I've made a `go-dev` docker image with tooling like: Go, Wire, Mockery, Psql

# Is it better than when you found it?


# Comments.
