### PR TITLE
EP-59: De-assign parking space from parking request if it has been updated to blocked/reserved

### DIFF
--- a/cmd/easypark/wire_gen.go
+++ b/cmd/easypark/wire_gen.go
@@ -69,7 +69,7 @@ func SetupApp() (*App, error) {
 	deteleParkingLot := usecases3.NewDeleteParkingLot(logrusLogger, parkingLotPostgresRepository)
 	getSingleParkingLot := usecases3.NewGetSingleParkingLot(logrusLogger, parkingLotPostgresRepository)
 	parkingLotFacade := usecasefacades.NewParkingLotFacade(createParkingLot, getAllParkingLots, deteleParkingLot, getSingleParkingLot)
-	updateParkingSpaceStatus := usecases4.NewUpdateParkingSpaceStatus(logrusLogger, parkingSpacePostgresRepository)
+	updateParkingSpaceStatus := usecases4.NewUpdateParkingSpaceStatus(logrusLogger, parkingSpacePostgresRepository, parkingRequestPostgresRepository)
 	getSingleParkingSpace := usecases4.NewGetSingleParkingSpace(logrusLogger, parkingSpacePostgresRepository)
 	parkingSpaceFacade := usecasefacades.NewParkingSpaceFacade(updateParkingSpaceStatus, getSingleParkingSpace)
 	notificationPostgresRepository := datastore.NewNotificationPostgresRepository(logrusLogger, gormWrapper)

--- a/docs/DESIGN.MD
+++ b/docs/DESIGN.MD
@@ -15,7 +15,7 @@ States a parking request can be in: `pending`, `approved`, `rejected`, `active` 
 
 - **Pending**:
   - All new parking requests are created a 'pending' status.
-  - _TODO: If the admin 'reserves' or 'blocks' a space assigned to parking request, it will change request's status to 'pending' and disassociate with that parking space in the system._
+  - If the admin 'reserves' or 'blocks' a space assigned to parking request, it will change request's status to 'pending' and disassociate with that parking space in the system.
   - If the assigned parking space is de-assigned.
 - **Approval Conditions**:
   - A parking request can only be approved if:

--- a/internal/usecases/parkingspace/update_parking_space_status.go
+++ b/internal/usecases/parkingspace/update_parking_space_status.go
@@ -61,10 +61,12 @@ func (s *UpdateParkingSpaceStatus) Execute(ctx context.Context, id uuid.UUID, st
 			}
 
 			for _, req := range parkingRequests {
-				req.ParkingSpaceID = nil // De-assign this space.
+				req.OnSpaceDeassign()
 				s.requestRepo.Save(ctx, &req)
 			}
-			s.logger.WithField("park reqs", parkingRequests).Debug("de-assigned parking space")
+
+			// Remove reference to parking requests.
+			parkSpace.ParkingRequests = nil
 		}
 	}
 

--- a/internal/usecases/parkingspace/update_parking_space_status.go
+++ b/internal/usecases/parkingspace/update_parking_space_status.go
@@ -46,21 +46,7 @@ func (s *UpdateParkingSpaceStatus) Execute(ctx context.Context, id uuid.UUID, st
 	if domainStatus == entities.ParkingSpaceStatusBlocked || domainStatus == entities.ParkingSpaceStatusReserved {
 		// De-assign from this parking space.
 		if parkSpace.ParkingRequests != nil {
-			var ids []uuid.UUID
 			for _, req := range parkSpace.ParkingRequests {
-				ids = append(ids, req.ID)
-			}
-
-			// Create the query map with ids
-			query := map[string]interface{}{
-				"id": ids,
-			}
-			parkingRequests, err := s.requestRepo.GetMany(ctx, query)
-			if err != nil {
-				return entities.ParkingSpace{}, err
-			}
-
-			for _, req := range parkingRequests {
 				req.OnSpaceDeassign()
 				s.requestRepo.Save(ctx, &req)
 			}

--- a/internal/usecases/parkingspace/update_parking_space_status_test.go
+++ b/internal/usecases/parkingspace/update_parking_space_status_test.go
@@ -51,6 +51,62 @@ func TestUpdateParkingSpaceStatus_Execute_HappyPath(t *testing.T) {
 	mockRepo.AssertExpectations(t)
 }
 
+func TestUpdateParkingSpaceStatus_Execute_HappyPath_Block(t *testing.T) {
+	// --------
+	// ASSEMBLE
+	// --------
+	testLogger, _ := test.NewNullLogger()
+	mockRepo := &mocks.ParkingSpaceRepository{}
+	mockReq := &mocks.ParkingRequestRepository{}
+	usecase := usecases.NewUpdateParkingSpaceStatus(testLogger, mockRepo, mockReq)
+
+	testCtx := context.Background()
+	testID := uuid.New()
+	testStatus := "blocked"
+	parkSpaceID := uuid.New()
+	testParkingRequests := []entities.ParkingRequest{
+		{
+			ID:             uuid.New(),
+			ParkingSpaceID: &parkSpaceID,
+		},
+		{
+			ID:             uuid.New(),
+			ParkingSpaceID: &parkSpaceID,
+		},
+	}
+	testParkingSpace := entities.ParkingSpace{
+		ID:              parkSpaceID,
+		ParkingLotID:    uuid.New(),
+		Name:            "main lot",
+		Status:          entities.ParkingSpaceStatusBlocked,
+		ParkingRequests: testParkingRequests,
+	}
+	mockRepo.EXPECT().GetSingle(testCtx, testID).Return(testParkingSpace, nil).Once()
+
+	for _, req := range testParkingRequests {
+		req.OnSpaceDeassign()
+		mockReq.EXPECT().Save(testCtx, &req).Return(nil).Once()
+	}
+
+	testParkingSpace.Status = entities.ParkingSpaceStatusBlocked
+	testParkingSpace.ParkingRequests = nil
+	mockRepo.EXPECT().Save(testCtx, &testParkingSpace).Return(nil).Once()
+
+	// --------
+	// ACT
+	// --------
+	space, err := usecase.Execute(testCtx, testID, testStatus)
+
+	// --------
+	// ASSERT
+	// --------
+	assert.Nil(t, err, "Error must be nil")
+	assert.Equal(t, entities.ParkingSpaceStatusBlocked, space.Status, "Space status must be blocked")
+	assert.Nil(t, space.ParkingRequests)
+	mockRepo.AssertExpectations(t)
+	mockReq.AssertExpectations(t)
+}
+
 func TestUpdateParkingSpaceStatus_Execute_UnhappyPath_FailedStatusParsing(t *testing.T) {
 	// --------
 	// ASSEMBLE

--- a/internal/usecases/parkingspace/update_parking_space_status_test.go
+++ b/internal/usecases/parkingspace/update_parking_space_status_test.go
@@ -20,7 +20,8 @@ func TestUpdateParkingSpaceStatus_Execute_HappyPath(t *testing.T) {
 	// --------
 	testLogger, _ := test.NewNullLogger()
 	mockRepo := &mocks.ParkingSpaceRepository{}
-	usecase := usecases.NewUpdateParkingSpaceStatus(testLogger, mockRepo)
+	mockReq := &mocks.ParkingRequestRepository{}
+	usecase := usecases.NewUpdateParkingSpaceStatus(testLogger, mockRepo, mockReq)
 
 	testCtx := context.Background()
 	testID := uuid.New()
@@ -56,8 +57,8 @@ func TestUpdateParkingSpaceStatus_Execute_UnhappyPath_FailedStatusParsing(t *tes
 	// --------
 	testLogger, hook := test.NewNullLogger()
 	mockRepo := &mocks.ParkingSpaceRepository{}
-	usecase := usecases.NewUpdateParkingSpaceStatus(testLogger, mockRepo)
-
+	mockReq := &mocks.ParkingRequestRepository{}
+	usecase := usecases.NewUpdateParkingSpaceStatus(testLogger, mockRepo, mockReq)
 	testCtx := context.Background()
 	testID := uuid.New()
 	testStatus := "invalid"
@@ -87,8 +88,8 @@ func TestUpdateParkingSpaceStatus_Execute_UnhappyPath_GetParkingSpaceError(t *te
 	// --------
 	testLogger, _ := test.NewNullLogger()
 	mockRepo := &mocks.ParkingSpaceRepository{}
-	usecase := usecases.NewUpdateParkingSpaceStatus(testLogger, mockRepo)
-
+	mockReq := &mocks.ParkingRequestRepository{}
+	usecase := usecases.NewUpdateParkingSpaceStatus(testLogger, mockRepo, mockReq)
 	testCtx := context.Background()
 	testID := uuid.New()
 	testStatus := "available"

--- a/tests/functional/parking_space_update_status_test.go
+++ b/tests/functional/parking_space_update_status_test.go
@@ -109,6 +109,89 @@ func (s *TestUpdateParkingSpaceStatusSuite) TestUpdateParkingSpaceStatusSuite_Un
 	s.Require().Equal("failed to parse given status\n", string(respBody))
 }
 
+func (s *TestUpdateParkingSpaceStatusSuite) TestUpdateParkingSpaceStatusSuite_Block_DeassignsSpace() {
+	// ---------
+	// ASSEMBLE
+	// ---------
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	driver, driverToken := utils.CreateAndLoginDriver(ctx, &s.RestClientSuite, nil)
+	adminToken := utils.CreateAndLoginAdmin(ctx, &s.RestClientSuite)
+	parkingLot := utils.CreateParkingLot(ctx, adminToken, nil, &s.RestClientSuite)
+	parkingSpaceID := parkingLot.ParkingSpaces[0].ID
+
+	// Create parking requests.
+	createRequests := []models.CreateParkingRequestRequest{
+		{
+			DestinationParkingLotID: parkingLot.ID,
+			StartTime:               time.Now().Add(5 * time.Minute),
+			EndTime:                 time.Now().Add(15 * time.Minute),
+		},
+		{
+			DestinationParkingLotID: parkingLot.ID,
+			StartTime:               time.Now().Add(20 * time.Minute),
+			EndTime:                 time.Now().Add(35 * time.Minute),
+		},
+		{
+			DestinationParkingLotID: parkingLot.ID,
+			StartTime:               time.Now().Add(45 * time.Minute),
+			EndTime:                 time.Now().Add(60 * time.Minute),
+		},
+	}
+	var parkingRequests []models.CreateParkingRequestResponse
+	for _, req := range createRequests {
+		parkingRequest := utils.CreateParkingRequest(ctx, driverToken, driver.ID, parkingLot.ID, &req, &s.RestClientSuite)
+		parkingRequests = append(parkingRequests, parkingRequest)
+	}
+
+	// Assign the space to those requests.
+	for _, parkingReq := range parkingRequests {
+		utils.AssignParkingSpace(ctx, parkingSpaceID, parkingReq.ID, adminToken, &s.RestClientSuite)
+	}
+
+	updateRequest := &models.UpdateParkingSpaceStatus{
+		Status: "blocked",
+	}
+
+	// ---------
+	// ACT
+	// ---------
+	respBody, respCode, err := s.UpdateParkingSpaceStatus(ctx, adminToken, parkingSpaceID, updateRequest)
+
+	// ---------
+	// ASSERT
+	// ---------
+	s.Require().NoError(err, "No error must be returned when updating parking space status")
+	s.Require().Equal(http.StatusOK, respCode, "Response code should be 200")
+	// Unmarshal response.
+	var targetSpaceModel entities.ParkingSpace
+	err = s.UnmarshalHTTPResponse(respBody, &targetSpaceModel)
+	s.Require().NoError(err, "failed to unmarshall response")
+	s.Require().Equal(entities.ParkingSpaceStatusBlocked, targetSpaceModel.Status, "Wrong status")
+
+	// Check parking space doesn't have any parking requests.
+	respBody, respCode, err = s.GetSingleParkingSpace(ctx, adminToken, parkingSpaceID.String())
+	s.Require().NoError(err, "No error must be returned when updating parking space status")
+	s.Require().Equal(http.StatusOK, respCode, "Response code should be 200")
+	// Unmarshal response.
+	var space entities.ParkingSpace
+	err = s.UnmarshalHTTPResponse(respBody, &space)
+	s.Require().NoError(err, "failed to unmarshal response")
+	s.Require().Empty(space.ParkingRequests)
+
+	// Check parking requests don't have parking space id set.
+	respBody, respCode, err = s.GetAllParkingRequests(ctx, adminToken)
+	s.Require().NoError(err, "No error must be returned when updating parking space status")
+	s.Require().Equal(http.StatusOK, respCode, "Response code should be 200")
+	// Unmarshal response.
+	var requests []entities.ParkingRequest
+	err = s.UnmarshalHTTPResponse(respBody, &requests)
+	s.Require().NoError(err, "failed to unmarshal response")
+	for _, req := range requests {
+		s.Require().Nil(req.ParkingSpaceID)
+	}
+}
+
 func TestUpdateParkingSpaceStatusSuiteInit(t *testing.T) {
 	suite.Run(t, new(TestUpdateParkingSpaceStatusSuite))
 }


### PR DESCRIPTION
# Ticket link.
EP-59

# Why have you made these changes? What problem it fixes?
If admin blocks/reserved parking space that has been assigned to parking requests, it should severe this association, move requests to pending state

# What does this implement? Explain your changes.


# Is it better than when you found it?


# Comments.
